### PR TITLE
add 'R'eally 'd'elete remap, add macvim font size override

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -74,4 +74,12 @@ if has('macunix')
     nnoremap + :vert res +5<CR>
     "shift + minus (_):
     nnoremap _ :vert res -5<CR>
+
+  "Font size override for MacVim:
+  set guifont=Menlo\ Regular:h18
+
 endif
+
+"Really delete (send contents to blackhole register)
+"from https://stackoverflow.com/a/3641942/3291472:
+nnoremap R "_d


### PR DESCRIPTION
This PR adds MacVim/gVim font size override along with a key remap to send contents straight to black hole register. We'll see if I want to keep this vs. just using the direct bind `"_d`.

It's also worth mentioning that this remap replaces the default bind for "replace mode", but I don't currently use that so that isn't an issue.